### PR TITLE
Fix script error when sodium or toxcore are not needed.

### DIFF
--- a/bin/travis-haskell
+++ b/bin/travis-haskell
@@ -21,8 +21,8 @@ travis-script() {
   export LD_LIBRARY_PATH=$HOME/.local/lib
   export PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig
   
-  NEED_SODIUM=$(stack ls dependencies --test | grep saltine > /dev/null && echo 1)
-  NEED_TOXCORE=$(grep 'extra-libraries:.*toxcore' *.cabal > /dev/null && echo 1)
+  NEED_SODIUM=$(stack ls dependencies --test | grep saltine > /dev/null && echo 1 || echo 0)
+  NEED_TOXCORE=$(grep 'extra-libraries:.*toxcore' *.cabal > /dev/null && echo 1 || echo 0)
   
   if [ -n "$NEED_SODIUM" ]; then
     NEED_TOXCORE=1


### PR DESCRIPTION
The `&&` made it so it would error if the lhs of the conjunction failed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tools/13)
<!-- Reviewable:end -->
